### PR TITLE
Fix lazy scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # dataframe_library_comparison
-Repository to show the disadvantages and advantages of the different most commonly used dataframe packages. Pandas v1, Pandas v2, Polars Lazy, Polars Eager, Pyspark single-node and Pyspark multi-node. The complete post can be found here: 
+Repository to show the disadvantages and advantages of the different most commonly used dataframe packages. Pandas v1, Pandas v2, Polars Lazy, Polars Eager, Pyspark single-node and Pyspark multi-node. The complete post can be found here: https://medium.com/@jakob.damen/which-dataframe-library-to-choose-for-your-next-data-science-project-b5bd2db3e394
+
+*How to use this repo:*
+You can generate your own simulated data by running the src/data/generate_and_save_data.ipynb notebook. You can add your own scenario or use the 6 pre-defined data sizes. The generate files will be written to the src/data/data_files folder as parquet files.
+Once you have some simulated data you can run the different versions of the dataframe libraries via the src/trigger_dataframe_technology.ipynb notebook. Set your data set (scneario) and initiate the dataframe library you want to test. 
+In case you want to add additional dataframe libraries or different settings for an existing library, you can copy and fill in the template_for_new_technologies.py file.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # dataframe_library_comparison
 Repository to show the disadvantages and advantages of the different most commonly used dataframe packages. Pandas v1, Pandas v2, Polars Lazy, Polars Eager, Pyspark single-node and Pyspark multi-node. The complete post can be found here: https://medium.com/@jakob.damen/which-dataframe-library-to-choose-for-your-next-data-science-project-b5bd2db3e394
 
+
 *How to use this repo:*
+
 You can generate your own simulated data by running the src/data/generate_and_save_data.ipynb notebook. You can add your own scenario or use the 6 pre-defined data sizes. The generate files will be written to the src/data/data_files folder as parquet files.
+
 Once you have some simulated data you can run the different versions of the dataframe libraries via the src/trigger_dataframe_technology.ipynb notebook. Set your data set (scneario) and initiate the dataframe library you want to test. 
 In case you want to add additional dataframe libraries or different settings for an existing library, you can copy and fill in the template_for_new_technologies.py file.

--- a/src/polars_lazy.py
+++ b/src/polars_lazy.py
@@ -19,21 +19,21 @@ class PolarsLazy:
     @timer
     def load_data(self):
         """TASK 0: Load the data from the save location"""
-        customer_database = pl.read_parquet(self.save_location / f"customer_database.parquet").lazy()
+        customer_database = pl.scan_parquet(self.save_location / f"customer_database.parquet")
         customer_database = customer_database.select(
             pl.col("customer_id").cast(pl.String),
             pl.col("brand_happiness").cast(pl.Float64),
         )
         self.customer_database = customer_database
 
-        store_visits = pl.read_parquet(self.save_location / f"store_visits.parquet").lazy()
+        store_visits = pl.scan_parquet(self.save_location / f"store_visits.parquet")
         store_visits = store_visits.select(
             pl.col("customer_id").cast(pl.String),
             pl.col("datetime").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M"),
         )
         self.store_visits = store_visits
 
-        advertisements = pl.read_parquet(self.save_location / f"advertisements.parquet").lazy()
+        advertisements = pl.scan_parquet(self.save_location / f"advertisements.parquet")
         advertisements = advertisements.select(
             pl.col("datetime").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M"),
             pl.col("channel").cast(pl.String),
@@ -41,7 +41,7 @@ class PolarsLazy:
         )
         self.advertisements = advertisements
 
-        revenue = pl.read_parquet(self.save_location / f"revenue.parquet").lazy()
+        revenue = pl.scan_parquet(self.save_location / f"revenue.parquet")
         revenue = revenue.select(
             pl.col("datetime").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M"),
             pl.col("revenue").cast(pl.Float32),


### PR DESCRIPTION
Calling read instantly gets the whole file into memory, reducing possible optimizations. Performance is likely better with scan instead.